### PR TITLE
ipv4: fix const

### DIFF
--- a/ipv4/zsys_linux_loong64.go
+++ b/ipv4/zsys_linux_loong64.go
@@ -57,6 +57,11 @@ const (
 	sysSO_EE_ORIGIN_ICMP6        = 0x3
 	sysSO_EE_ORIGIN_TXSTATUS     = 0x4
 	sysSO_EE_ORIGIN_TIMESTAMPING = 0x4
+	
+	sizeofInetPktinfo = 0xc
+	sizeofICMPFilter = 0x4
+	sizeofGroupReq = 0x88
+	sizeofGroupSourceReq = 0x108
 )
 
 type kernelSockaddrStorage struct {


### PR DESCRIPTION
fix compile error:
	x/net/ipv4/sys_linux.go:21:36: undefined: sizeofInetPktinfo
	x/net/ipv4/sys_linux.go:33:108: undefined: sizeofICMPFilter
	x/net/ipv4/sys_linux.go:34:107: undefined: sizeofGroupReq
	x/net/ipv4/sys_linux.go:35:108: undefined: sizeofGroupReq
	x/net/ipv4/sys_linux.go:36:114: undefined: sizeofGroupSourceReq
	x/net/ipv4/sys_linux.go:37:115: undefined: sizeofGroupSourceReq
	x/net/ipv4/sys_linux.go:38:109: undefined: sizeofGroupSourceReq
	x/net/ipv4/sys_linux.go:39:111: undefined: sizeofGroupSourceReq
	x/net/ipv4/control_pktinfo.go:22:52: undefined: sizeofInetPktinfo
	x/net/ipv4/control_pktinfo.go:24:47: undefined: sizeofInetPktinfo
	x/net/ipv4/control_pktinfo.go:24:47: too many errors